### PR TITLE
Upgrade to Proguard 5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                     <dependency>
                         <groupId>net.sf.proguard</groupId>
                         <artifactId>proguard-base</artifactId>
-                        <version>5.0</version>
+                        <version>5.1</version>
                         <scope>runtime</scope>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
Fails with:

 [proguard] Reading library jar [/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/rt.jar]
 [proguard] Error: 4
